### PR TITLE
This fixes the problem with KVM problem.  When you switch keyboads

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,15 @@ Hosts=server1, server2, server3
 #   computer should not take action if any of the hosts declared here is
 #   still up (responding to ping).
 
+# disks parameter (list of disknames , separated by commas):
+#
+#   Here you list the list of disknames your machine is dependant, i.e. this
+#   computer should not shutdown if any of the disks declared here is
+#   still active.
+[DISKS]
+disks=
+
+
 [RESOURCES]
 CpuPercentage=Disabled
 

--- a/etc/autopoweroff/autopoweroff.conf
+++ b/etc/autopoweroff/autopoweroff.conf
@@ -58,6 +58,15 @@ Hosts=server1, server2, server3
 #   computer should not take action if any of the hosts declared here is
 #   still up (responding to ping).
 
+# disks parameter (list of disknames , separated by commas):
+#
+#   Here you list the list of disknames your machine is dependant, i.e. this
+#   computer should not shutdown if any of the disks declared here is
+#   still active.
+[DISKS]
+disks=
+
+
 [RESOURCES]
 CpuPercentage=Disabled
 

--- a/python/modules/ApoObserverDevice.py
+++ b/python/modules/ApoObserverDevice.py
@@ -7,6 +7,7 @@ import time
 import re
 import os
 import errno
+from pathlib import Path
 
 from ApoLibrary import *
 from ApoObserver import *
@@ -125,10 +126,13 @@ class ApoObserverDevice(ApoObserverThread):
         fd.read(1)
       except IOError as ioerror:
         if ioerror.errno == errno.ENODEV:
-          self.finish = True
           sendmsg("Device " + self.sDevice + " absent (No such device error)", \
                   priority=syslog.LOG_NOTICE)
           continue
+          fd.close()
+          while not Path('/dev/input/mouse1').exists():
+            time.sleep(60)
+          fd = open(self.sDevice, 'rb')
         else:
           raise
       currentTime = time.time()

--- a/python/modules/ApoObserverDevice.py
+++ b/python/modules/ApoObserverDevice.py
@@ -81,7 +81,6 @@ class ApoObserverDeviceManager(ApoObserverManager):
   # Return True if the time elapsed since the lastInputEventTime is bigger
   # that that of the configuration IdleTime.
   def status(self):
-    print("self.configuration = " + str(self.configuration.idletime))
     elapsedTimeSinceLastEvent = time.time() - self.lastInputEventTime
     condition = elapsedTimeSinceLastEvent > self.configuration.idletime * 60
     self.logger.debug(f"elapsedTimeSinceLastEvent = {elapsedTimeSinceLastEvent:0.2f} condition = {condition}")
@@ -128,11 +127,12 @@ class ApoObserverDevice(ApoObserverThread):
         if ioerror.errno == errno.ENODEV:
           sendmsg("Device " + self.sDevice + " absent (No such device error)", \
                   priority=syslog.LOG_NOTICE)
-          continue
           fd.close()
           while not Path('/dev/input/mouse1').exists():
             time.sleep(60)
+          time.sleep(1)
           fd = open(self.sDevice, 'rb')
+          continue
         else:
           raise
       currentTime = time.time()

--- a/python/modules/ApoObserverDevice.py
+++ b/python/modules/ApoObserverDevice.py
@@ -128,9 +128,8 @@ class ApoObserverDevice(ApoObserverThread):
           sendmsg("Device " + self.sDevice + " absent (No such device error)", \
                   priority=syslog.LOG_NOTICE)
           fd.close()
-          while not Path('/dev/input/mouse1').exists():
+          while not Path(self.sDevice).exists():
             time.sleep(60)
-          time.sleep(1)
           fd = open(self.sDevice, 'rb')
           continue
         else:

--- a/python/modules/ApoObserverDisk.py
+++ b/python/modules/ApoObserverDisk.py
@@ -45,10 +45,6 @@ class ApoObserverDiskManager(threading.Thread):
     else:
       return ( False, "DiskTime", f"✘ Last event time happened over {elapsedTimeSinceLastEvent:0.1} mins, lower than configuration IdleTime parameter set to {self.configuration.idletime:0} mins." )
   def run(self):
-    st = open('/proc/thread-self/stat','r')
-    tid, junk = (st.readline(9)).split()
-    sendmsg("Disk Thread Id = " + str(tid))
-    st.close()
     fd = open(self.DiskFile, 'r')
     sendmsg("ApoObserverDisk.run():  Check on " +
                      str(self.disksToWatch) + " started.")

--- a/python/modules/ApoObserverDisk.py
+++ b/python/modules/ApoObserverDisk.py
@@ -1,0 +1,87 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import threading
+import logging
+import time
+import re
+import os
+
+from ApoLibrary import *
+
+class ApoObserverDiskManager(threading.Thread):
+
+  def __init__(self, configuration):
+    threading.Thread.__init__(self, name="ApoObserverDisk")
+    self.configuration = configuration
+    self.lastDiskEventTime = time.time()
+    self.DiskFile = '/proc/diskstats'
+    self.disksToWatch = configuration.disksToWatch
+    self.logger             = logging.getLogger("apo.observer.device.manager")
+    self.setDaemon(True)
+
+  global diskstats
+  def diskstats(fd,diskname):
+      line = fd.readline()
+      y=0
+      while line:
+        if re.search(diskname,line):
+          data = line.split()
+          for x in range(3, 13):
+            y += int(data[x],10)
+        line = fd.readline()
+      fd.seek(0)
+      return y
+  def status(self):
+    elapsedTimeSinceLastEvent = time.time() - self.lastDiskEventTime
+    condition = elapsedTimeSinceLastEvent > self.configuration.idletime * 60
+#    print(" disk status " + str(elapsedTimeSinceLastEvent) + " " + str(self.lastDiskEventTime) + " " +str(condition))
+    self.logger.debug(f"elapsedTimeSinceLastEvent = {elapsedTimeSinceLastEvent:0.2f} condition = {condition}")
+
+    # Converting to minutes to make it eaiser 
+    elapsedTimeSinceLastEvent = elapsedTimeSinceLastEvent / 60.0
+    if condition :
+      return ( True,  "DiskTime", f"✓ Last event time happened over {elapsedTimeSinceLastEvent:0.1} mins, greater than configuration IdleTime parameter set to {self.configuration.idletime:0} mins." )
+    else:
+      return ( False, "DiskTime", f"✘ Last event time happened over {elapsedTimeSinceLastEvent:0.1} mins, lower than configuration IdleTime parameter set to {self.configuration.idletime:0} mins." )
+  def run(self):
+    st = open('/proc/thread-self/stat','r')
+    tid, junk = (st.readline(9)).split()
+    sendmsg("Disk Thread Id = " + str(tid))
+    st.close()
+    fd = open(self.DiskFile, 'r')
+    sendmsg("ApoObserverDisk.run():  Check on " +
+                     str(self.disksToWatch) + " started.")
+    self.finish = False
+    diskActivity = {} 
+    cnt=0
+    for diskname in self.disksToWatch:
+      diskActivity[diskname]=0
+    while not self.finish:
+      y=0
+      time.sleep(60)
+
+      for diskname in self.disksToWatch:
+        y = diskstats(fd,diskname)
+        if (cnt % 10) == 0:
+          sendmsg(f"diskstats {diskname} = {y} ")
+        cnt+=1
+        if y > diskActivity[diskname]: 
+          diskActivity[diskname] = y
+          currentTime = time.time()
+      # print currentTime-lastDiskEventTime
+      # To reduce the quantity of output, we print only a few
+      # of the events, for logger.debugging purposes.  Else, it is simply
+      # to much.
+      if currentTime > self.lastDiskEventTime + 0.01:
+        self.logger.debug(
+            "ApoObserverDisk.run():  Activity detected on " + \
+            str(self.disksToWatch) + " at " + str(currentTime))
+      self.lastDiskEventTime = currentTime
+    fd.close()
+
+  def terminate(self):
+    self.finish = True
+
+  def sleep(self, timeout):
+    self.sleep = timeout

--- a/sbin/autopoweroff-gui.in
+++ b/sbin/autopoweroff-gui.in
@@ -349,7 +349,7 @@ def on_SbResourcesCpuPercentage_change(*args):
 def readConfiguration():
   global LMConfigHosts
 
-  configuration = ApoConfig.Configuration(None, None, None, None, None, None, False)
+  configuration = ApoConfig.Configuration(None, None, None, None, None, None, None, False)
   try:
     configuration.read()
   except ApoConfig.APOWarning:

--- a/sbin/autopoweroffd.in
+++ b/sbin/autopoweroffd.in
@@ -108,6 +108,7 @@ signal.signal(signal.SIGTERM, sigtermHandler)
 # Configuration
 import ApoConfig
 cancelfile = rundir + "/" + ApoConfig.CANCELFILENAME
+sendmsg("cancelfile = " + cancelfile)
 
 configuration = ApoConfig.Configuration(None, None, None, None)
 try:
@@ -133,6 +134,7 @@ else:
   commandtext = APOCommand.commands[configuration.action]
 
 sendmsg("Command to execute when all conditions are met:  " + command)
+sendmsg("disksToWatch= " + str(configuration.disksToWatch))
 
 ######################################################################
 # Starting thread that checks if any host is still alive.
@@ -159,6 +161,11 @@ apoObserverNoActionTimeRange.start()
 import ApoObserverDevice
 apoObserverDeviceManager = \
   ApoObserverDevice.ApoObserverDeviceManager(configuration)
+
+import ApoObserverDisk
+apoObserverDisks = \
+  ApoObserverDisk.ApoObserverDiskManager(configuration)
+apoObserverDisks.start()
 
 import ApoObserverResources
 apoObserverResources = ApoObserverResources.ApoObserverResources(configuration)
@@ -205,6 +212,7 @@ try:
       setConditions(apoObserverNoActionTimeRange.status())
       setConditions(apoObserverDeviceManager.status())
       setConditions(apoObserverResources.status())
+      setConditions(apoObserverDisks.status())
 
       logger.debug("conditionsState:  " + str(conditionsState))
       logger.debug("previousConditionsState:  " + str(previousConditionsState))


### PR DESCRIPTION
autopoweroff the threads that monitor keyboard and mouse activity
terminate.  When the keyboard or mouse is removed from the PC.
When the keyboard and mouse is switched back the /dev/input/mouse1 file is created.
So instead of terminating the thread we close the file wait for the /dev/input/mouse1
file which indicates the device have returned.  So reopen the file and go back to monitoring
for activity.